### PR TITLE
US6959 Javascript for Header in Phoenix and CMS

### DIFF
--- a/apps/crossroads_interface/web/static/js/app.js
+++ b/apps/crossroads_interface/web/static/js/app.js
@@ -1,7 +1,14 @@
-import "phoenix_html"
+//import "phoenix_html"
 
 // include all svg files in icons directory in the body of the document
 //var files = require.context('../icons', false, /.svg$/);
 //files.keys().forEach(files);
 
 // import socket from "./socket"
+
+export var App = {
+  run: function(){
+    var pastoralCare = document.getElementById("pastoralCare");
+    pastoralCare.addEventListener("click", function() { alert("Hello from Phoenix JavaScript!"); });
+  }
+}

--- a/apps/crossroads_interface/web/templates/layout/legacy.html.eex
+++ b/apps/crossroads_interface/web/templates/layout/legacy.html.eex
@@ -1,7 +1,9 @@
-<%= render CrossroadsInterface.SharedView, "header.html", assigns %>
+<script type="text/javascript" src="<%= static_path(@conn, "/js/app.js") %>"></script>
 
+<%= render CrossroadsInterface.SharedView, "header.html", assigns %>
 
 <%= render @view_module, @view_template, assigns %>
 
-
 <%= render CrossroadsInterface.SharedView, "footer.html", assigns %>
+
+<script>require("web/static/js/app").App.run()</script>

--- a/apps/crossroads_interface/web/templates/shared/header.html.eex
+++ b/apps/crossroads_interface/web/templates/shared/header.html.eex
@@ -100,7 +100,7 @@
             </ul>
 
             <!--MAIN NAV MENU-->
-            <%= raw(filter_content_blocks(@content_blocks, "mainNavMenu")["content"]) %>
+            <%= raw(filter_content_blocks(@content_blocks, "mainPhoenixMenu")["content"]) %>
           </div>
         </div><!--/col-->
       </div><!--/row-->


### PR DESCRIPTION
Javascript that manipulates header now lives in phoenix app.js file. As
part of this work, the javascript was also added inline in the CMS to
prove that javascript in the CMS can be run after a page loads.